### PR TITLE
Implement SerializedFile serialization

### DIFF
--- a/Snuggle.Core/Models/Serialization/UnityExternalInfo.cs
+++ b/Snuggle.Core/Models/Serialization/UnityExternalInfo.cs
@@ -40,4 +40,25 @@ public record UnityExternalInfo(string Path, Guid Guid, int Type, string AssetPa
 
         return array;
     }
+    
+    public static void ArrayToWriter(BiEndianBinaryWriter writer, UnityExternalInfo[] infos, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        writer.Write(infos.Length);
+        foreach (var info in infos) {
+            info.ToWriter(writer, header, options, serializationOptions);
+        }
+    }
+
+    public void ToWriter(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        if (serializationOptions.TargetFileVersion >= UnitySerializedFileVersion.ExternalExtraPath) {
+            writer.WriteNullString(Path);
+        }
+
+        if (serializationOptions.TargetFileVersion >= UnitySerializedFileVersion.ExternalGuid) {
+            writer.Write(Guid.ToByteArray());
+            writer.Write(Type);
+        }
+
+        // TODO: Should we store the original path that was not modified and use it here?
+        writer.WriteNullString(AssetPath);
+    }
 }

--- a/Snuggle.Core/Models/Serialization/UnityScriptInfo.cs
+++ b/Snuggle.Core/Models/Serialization/UnityScriptInfo.cs
@@ -28,4 +28,20 @@ public record UnityScriptInfo(int Index, long PathId) {
 
         return array;
     }
+    
+    public static void ArrayToWriter(BiEndianBinaryWriter writer, UnityScriptInfo[] infos, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        writer.Write(infos.Length);
+        foreach (var info in infos) {
+            info.ToWriter(writer, header, options, serializationOptions);
+        }
+    }
+
+    public void ToWriter(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        if (serializationOptions.TargetFileVersion >= UnitySerializedFileVersion.BigIdAlwaysEnabled) {
+            writer.Align();
+        }
+
+        writer.Write(Index);
+        writer.Write(PathId);
+    }
 }

--- a/Snuggle.Core/Models/Serialization/UnityTypeTree.cs
+++ b/Snuggle.Core/Models/Serialization/UnityTypeTree.cs
@@ -7,7 +7,8 @@ using Snuggle.Core.Options;
 namespace Snuggle.Core.Models.Serialization;
 
 public record UnityTypeTree(UnityTypeTreeNode[] Nodes, Memory<byte> StringBuffer) {
-    public static UnityTypeTree FromReader(BiEndianBinaryReader reader, UnitySerializedFile header, SnuggleCoreOptions options) => header.FileVersion is >= UnitySerializedFileVersion.TypeTreeBlob or UnitySerializedFileVersion.TypeTreeBlobBeta ? FromReaderBlob(reader, header, options) : FromReaderLegacy(reader, header, options);
+    public static UnityTypeTree FromReader(BiEndianBinaryReader reader, UnitySerializedFile header, SnuggleCoreOptions options) =>
+        header.FileVersion is >= UnitySerializedFileVersion.TypeTreeBlob or UnitySerializedFileVersion.TypeTreeBlobBeta ? FromReaderBlob(reader, header, options) : FromReaderLegacy(reader, header, options);
 
     private static UnityTypeTree FromReaderLegacy(BiEndianBinaryReader reader, UnitySerializedFile header, SnuggleCoreOptions options) => new(UnityTypeTreeNode.ArrayFromReaderLegacy(reader, header, options, 1, 0), Memory<byte>.Empty);
 
@@ -28,6 +29,24 @@ public record UnityTypeTree(UnityTypeTreeNode[] Nodes, Memory<byte> StringBuffer
         }
 
         return new UnityTypeTree(nodes, buffer);
+    }
+
+    public void ToWriter(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        if (serializationOptions.TargetFileVersion is >= UnitySerializedFileVersion.TypeTreeBlob or UnitySerializedFileVersion.TypeTreeBlobBeta)
+            ToWriterBlob(writer, header, options, serializationOptions);
+        else
+            ToWriterLegacy(writer, header, options, serializationOptions);
+    }
+
+    private void ToWriterBlob(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        writer.Write(Nodes.Length);
+        writer.Write(StringBuffer.Length);
+        foreach (var node in Nodes) node.ToWriter(writer, header, options, serializationOptions);
+        writer.Write(StringBuffer.Span);
+    }
+
+    private void ToWriterLegacy(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        throw new NotSupportedException("Writing legacy type trees is currently not supported");
     }
 
     public string PrintLayout(bool fullInfo, bool skipIgnored) {

--- a/Snuggle.Core/Models/Serialization/UnityTypeTreeNode.cs
+++ b/Snuggle.Core/Models/Serialization/UnityTypeTreeNode.cs
@@ -101,6 +101,20 @@ public record UnityTypeTreeNode(
         return list.ToArray();
     }
 
+    public void ToWriter(BiEndianBinaryWriter writer, UnitySerializedFile header, SnuggleCoreOptions options, AssetSerializationOptions serializationOptions) {
+        writer.Write((short)Version);
+        writer.Write((byte)Level);
+        writer.Write((byte)ArrayKind);
+        writer.Write(TypeOffset);
+        writer.Write(NameOffset);
+        writer.Write(Size);
+        writer.Write(Index);
+        writer.Write((uint)Flags);
+        if (serializationOptions.TargetFileVersion >= UnitySerializedFileVersion.TypeFlags) {
+            writer.Write(TypeHash);
+        }
+    }
+
     public static string GetString(uint offset, Span<byte> buffer) {
         var safeOffset = (int) (offset & 0x7FFFFFFF);
         if (safeOffset >= buffer.Length) {


### PR DESCRIPTION
This is an initial implementation of SerializedFile serialization.

The output file is currently not necessarily identical to the original file. This makes verifying the implementation more difficult. This is due to the two following issues:
* ObjectInfos in SerializedFile is a Dictionary, which can lose order,
* UnityExternalInfo.FromReader replaces resources/ with Resources/ on some Unity versions.

Additional limitations:
* Old files may not write correctly, as the seek to the end of the file while writing is broken. Old TypeTrees can't be written.
* Writing the resource stream is currently not supported.

Currently only copying original objects was tested.